### PR TITLE
Another Attempt To Fix Memory Leak in SRPG6

### DIFF
--- a/BGAnimations/_shared background/FactionVideo.lua
+++ b/BGAnimations/_shared background/FactionVideo.lua
@@ -1,0 +1,17 @@
+local static_alpha = 1
+local faction = SL.SRPG6.GetFactionName(SL.Global.ActiveColorIndex)
+
+local StaticBackgroundVideos = {
+	["Unaffiliated"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Fog.mp4"),
+	["Democratic People's Republic of Timing"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Ranni.mp4"),
+	["Footspeed Empire"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Malenia.mp4"),
+	["Stamina Nation"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Melina.mp4"),
+}
+
+return Def.Sprite{
+	Name="Video",
+	Texture=StaticBackgroundVideos[faction],
+	InitCommand=function(self)
+		self:rotationx(0):blend("BlendMode_Normal"):diffusealpha(static_alpha):diffuse(GetCurrentColor(true))
+	end
+}

--- a/BGAnimations/_shared background/FogVideo.lua
+++ b/BGAnimations/_shared background/FogVideo.lua
@@ -1,0 +1,8 @@
+local shared_alpha = 0.6
+return Def.Sprite{
+	Name="Video",
+	Texture=THEME:GetPathG("", "_VisualStyles/SRPG6/Fog.mp4"),
+	InitCommand=function(self)
+		self:rotationx(180):blend("BlendMode_Add"):diffusealpha(shared_alpha)
+	end
+}

--- a/BGAnimations/_shared background/Static.lua
+++ b/BGAnimations/_shared background/Static.lua
@@ -36,13 +36,6 @@ local SharedBackground = {
 	["ScreenThemeOptions"] = true,
 }
 
-local StaticBackgroundVideos = {
-	["Unaffiliated"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Fog.mp4"),
-	["Democratic People's Republic of Timing"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Ranni.mp4"),
-	["Footspeed Empire"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Malenia.mp4"),
-	["Stamina Nation"] = THEME:GetPathG("", "_VisualStyles/SRPG6/Melina.mp4"),
-}
-
 local shared_alpha = 0.6
 local static_alpha = 1
 
@@ -63,19 +56,21 @@ local af = Def.ActorFrame {
 			local static = self:GetChild("Static")
 			local video = self:GetChild("Video")
 			if SharedBackground[screen:GetName()] and not self.IsShared then
+				self:RemoveChild("Video")
 				static:visible(true)
-				video:Load(THEME:GetPathG("", "_VisualStyles/SRPG6/Fog.mp4"))
-				video:rotationx(180):blend("BlendMode_Add"):diffusealpha(shared_alpha):diffuse(color("#ffffff"))
+				self:AddChildFromPath( THEME:GetPathB("_shared","background/FogVideo.lua" ) )
+				-- video:Load(THEME:GetPathG("", "_VisualStyles/SRPG6/Fog.mp4"))
+				-- video:rotationx(180):blend("BlendMode_Add"):diffusealpha(shared_alpha):diffuse(color("#ffffff"))
 				self.IsShared = true
 			end
 			if not SharedBackground[screen:GetName()] and self.IsShared then
-				local faction = SL.SRPG6.GetFactionName(SL.Global.ActiveColorIndex)
 				-- No need to change anything for Unaffiliated.
 				-- We want to keep using the SharedBackground.
+				static:visible(false)
 				if faction ~= "Unaffiliated" then
-					static:visible(false)
-					video:Load(StaticBackgroundVideos[faction])
-					video:rotationx(0):blend("BlendMode_Normal"):diffusealpha(static_alpha):diffuse(GetCurrentColor(true))
+					self:RemoveChild("Video")
+					-- Load the new faction video to memory.
+					self:AddChildFromPath( THEME:GetPathB("_shared","background/FactionVideo.lua" ) )
 					self.IsShared = false
 				end
 			end
@@ -83,10 +78,11 @@ local af = Def.ActorFrame {
 	end,
 	VisualStyleSelectedMessageCommand=function(self)
 		local style = ThemePrefs.Get("VisualStyle")
-		if style == "SRPG6" then
-			self:visible(true)
+		if style ~= "SRPG6" then
+			-- Clean up the actorframe's video children from memory.
+			self:RemoveChild("Video")
 		else
-			self:visible(false)
+			self:AddChildFromPath( THEME:GetPathB("_shared","background/FogVideo.lua" ) )
 		end
 	end,
 	Def.Sprite {

--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -49,7 +49,6 @@ end
 
 function IsMinimumProductVersion(...)
 	local version = getProductVersion()
-
 	for i = 1, select('#', ...) do
 		local n = select(i, ...)
 		if not version[i] or n < version[i] then


### PR DESCRIPTION
Doing this process removes the need to generate separate versions, however it comes at the potential for special case backgrounds to not show up, as mentioned by Horsey.

(May not be needed as this commit https://github.com/Horsey-/Simply-Love-SM5-1/commit/7a1b7db649825ca48adf587fce10cd9281f8ecfd is already pushed)

> I try to make all my changes to Simply Love be easily tracked for when I have to rebase to the latest version, so making that change in the way backgrounds are loaded, it'll run into issues later when there are other special backgrounds added. 

The main limiting factor is the fact that every time `_shared background` is loaded, it will load a kind of screen depending on which one it is in.