### PR TITLE
Added .GetHeld

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
@@ -57,7 +57,7 @@ return Def.Actor{
 					
 					--OutFox doesn't yet support the GetHeld() function because of performance issues 
 					if not IsOutFox() then
-						if tnt ~= "Lift" and tns == "Miss" and tapnote:GetTapNoteResult():GetHeld() then
+						if tnt ~= "Lift" and tns == "Miss" and (tapnote:GetTapNoteResult().GetHeld and tapnote:GetTapNoteResult():GetHeld()) then
 							heldMiss = true
 						end
 					end

--- a/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentGraphics.lua
+++ b/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentGraphics.lua
@@ -107,7 +107,7 @@ for columnIndex=1,numColumns do
 					local tnt = ToEnumShortString(tapnote:GetTapNoteType())
 					if tnt == "Tap" or tnt == "HoldHead" or tnt == "Lift" then
 						local tns = ToEnumShortString(param.TapNoteScore)
-						if tnt ~= "Lift" and tns == "Miss" and tapnote:GetTapNoteResult():GetHeld() and ("Column"..col) == self:GetName() then
+						if tnt ~= "Lift" and tns == "Miss" and (tapnote:GetTapNoteResult().GetHeld and tapnote:GetTapNoteResult():GetHeld()) and ("Column"..col) == self:GetName() then
 							sprite:visible(true)
 							sprite:finishtweening():stopeffect()
 							-- this should match the custom JudgmentTween() from SL for 3.95

--- a/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentTracking.lua
@@ -78,7 +78,7 @@ if IsITGmania() then
 						judgments[col][tns] = judgments[col][tns] + 1
 
 						if tapnote:GetTapNoteResult().GetHeld then
-							if tnt ~= "Lift" and tns == "Miss" and tapnote:GetTapNoteResult():GetHeld() then
+							if tnt ~= "Lift" and tns == "Miss" and (tapnote:GetTapNoteResult().GetHeld and tapnote:GetTapNoteResult():GetHeld()) then
 								judgments[col].MissBecauseHeld = judgments[col].MissBecauseHeld + 1
 							end
 						end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/JudgmentBack.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/JudgmentBack.lua
@@ -264,7 +264,7 @@ return Def.ActorFrame{
 				local tnt = ToEnumShortString(tapnote:GetTapNoteType())
 				if tnt == "Tap" or tnt == "HoldHead" or tnt == "Lift" then
 					local tns = ToEnumShortString(param.TapNoteScore)
-					if tnt ~= "Lift" and tns == "Miss" and tapnote:GetTapNoteResult():GetHeld() then
+					if tnt ~= "Lift" and tns == "Miss" and (tapnote:GetTapNoteResult().GetHeld and tapnote:GetTapNoteResult():GetHeld()) then
 						isHeld = true
 					end
 				end


### PR DESCRIPTION
This should stop errors from appearing in ScreenGameplay when missing a note
<img width="1434" height="252" alt="image" src="https://github.com/user-attachments/assets/6c0bb8ba-588a-4f07-a4e6-795f31619bf7" />
